### PR TITLE
Refactor: Optimize LiveTable rendering performance

### DIFF
--- a/frontend/src/components/live-table/TableCell.tsx
+++ b/frontend/src/components/live-table/TableCell.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { Input } from "@/components/ui/input";
+import { CellPosition } from './LiveTableProvider'; // Assuming CellPosition is exported from LiveTableProvider
+
+// Define props for TableCell
+interface TableCellProps {
+  cellData: unknown; // Data for this specific cell
+  rowIndex: number;
+  colIndex: number;
+  header: string; // The header key for this cell's column
+  columnWidth: number;
+  isSelected: boolean; // Is this cell the primary selected cell (e.g., for focus ring)
+  isEditing: boolean;
+  isInSelectionArea: boolean; // Is this cell part of the broader selection area
+  handleCellMouseDown: (rowIndex: number, colIndex: number, event: React.MouseEvent) => void;
+  handleCellDoubleClick: (rowIndex: number, colIndex: number, event: React.MouseEvent) => void;
+  handleCellChange: (rowIndex: number, header: string, newValue: string) => void;
+  handleCellBlur: () => void;
+  setEditingCell: (cell: CellPosition | null) => void;
+}
+
+const TableCell: React.FC<TableCellProps> = React.memo(({
+  cellData,
+  rowIndex,
+  colIndex,
+  header,
+  columnWidth,
+  isSelected,
+  isEditing,
+  isInSelectionArea,
+  handleCellMouseDown,
+  handleCellDoubleClick,
+  handleCellChange,
+  handleCellBlur,
+  setEditingCell,
+}) => {
+  const cellKey = `${rowIndex}-${colIndex}`;
+
+  return (
+    <td
+      key={cellKey}
+      className="border p-0 relative"
+      data-row-index={rowIndex}
+      data-col-index={colIndex}
+      data-selected={isInSelectionArea ? "true" : "false"}
+      data-editing={isEditing ? "true" : "false"}
+      data-testid="table-cell"
+      style={{
+        width: `${columnWidth}px`,
+        minWidth: `${columnWidth}px`,
+        maxWidth: `${columnWidth}px`,
+        boxShadow: isSelected // Primary selected cell for focus
+          ? "inset 0 0 0 2px blue"
+          : isInSelectionArea // Part of a selected area
+          ? "inset 0 0 0 1px rgba(59, 130, 246, 0.5)"
+          : undefined,
+        backgroundColor: isEditing
+          ? "rgba(255, 255, 200, 0.2)"
+          : isInSelectionArea
+          ? "rgba(59, 130, 246, 0.1)"
+          : undefined,
+      }}
+      onMouseDown={(e) =>
+        handleCellMouseDown(rowIndex, colIndex, e)
+      }
+      onDoubleClick={(e) =>
+        handleCellDoubleClick(rowIndex, colIndex, e)
+      }
+    >
+      <input
+        type="text"
+        value={String(cellData ?? "")}
+        onChange={(e) =>
+          handleCellChange(rowIndex, header, e.target.value)
+        }
+        onBlur={() => {
+          handleCellBlur();
+          if (isEditing) {
+            setEditingCell(null);
+          }
+        }}
+        className={`w-full h-full p-2 border-none focus:outline-none ${
+          isEditing
+            ? "focus:ring-2 focus:ring-yellow-400" // Editing takes precedence for styling
+            : isSelected // Then primary selection
+            ? "focus:ring-2 focus:ring-blue-500" // Example: slightly different focus for primary selected
+            : "focus:ring-2 focus:ring-blue-300" // Default focus for non-selected/non-editing
+        } bg-transparent`}
+      />
+    </td>
+  );
+});
+
+TableCell.displayName = 'TableCell';
+
+export default TableCell;

--- a/frontend/src/components/live-table/TableCell.tsx
+++ b/frontend/src/components/live-table/TableCell.tsx
@@ -34,11 +34,8 @@ const TableCell: React.FC<TableCellProps> = React.memo(({
   handleCellBlur,
   setEditingCell,
 }) => {
-  const cellKey = `${rowIndex}-${colIndex}`;
-
   return (
     <td
-      key={cellKey}
       className="border p-0 relative"
       data-row-index={rowIndex}
       data-col-index={colIndex}

--- a/frontend/src/components/live-table/TableRow.tsx
+++ b/frontend/src/components/live-table/TableRow.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+// Remove Input import if no longer directly used here
+// import { Input } from "@/components/ui/input"; 
+import TableCell from './TableCell'; // Import TableCell
+import { CellPosition } from './LiveTableProvider';
+
+// Props remain largely the same, but some might be passed directly to TableCell
+interface TableRowProps {
+  rowData: Record<string, unknown>;
+  rowIndex: number;
+  headers: string[];
+  columnWidths: Record<string, number> | undefined;
+  selectedCell: CellPosition | null;
+  editingCell: CellPosition | null;
+  isCellSelected: (rowIndex: number, colIndex: number) => boolean; // To determine if cell is in selection area
+  handleCellMouseDown: (rowIndex: number, colIndex: number, event: React.MouseEvent) => void;
+  handleCellDoubleClick: (rowIndex: number, colIndex: number, event: React.MouseEvent) => void;
+  handleCellChange: (rowIndex: number, header: string, newValue: string) => void;
+  handleCellBlur: () => void;
+  setEditingCell: (cell: CellPosition | null) => void;
+  // Constants for styling, assuming these might be dynamic or from config later
+  ROW_NUMBER_COL_WIDTH: number;
+  DEFAULT_COL_WIDTH: number;
+}
+
+const TableRow: React.FC<TableRowProps> = React.memo(({
+  rowData,
+  rowIndex,
+  headers,
+  columnWidths,
+  selectedCell,
+  editingCell,
+  isCellSelected, // This prop helps determine if a cell is part of the general selection area
+  handleCellMouseDown,
+  handleCellDoubleClick,
+  handleCellChange,
+  handleCellBlur,
+  setEditingCell,
+  ROW_NUMBER_COL_WIDTH,
+  DEFAULT_COL_WIDTH,
+}) => {
+  return (
+    <tr key={`row-${rowIndex}`}> {/* Added prefix to key for clarity */}
+      <td
+        className="border border-slate-300 p-0 text-center"
+        style={{
+          width: `${ROW_NUMBER_COL_WIDTH}px`,
+          minWidth: `${ROW_NUMBER_COL_WIDTH}px`,
+          maxWidth: `${ROW_NUMBER_COL_WIDTH}px`,
+        }}
+        data-testid="row-number"
+      >
+        <div className="p-2 h-full flex items-center justify-center">
+          {rowIndex + 1}
+        </div>
+      </td>
+      {headers?.map((header, colIndex) => {
+        // Determine if this cell is THE selected cell (for primary selection indication)
+        const isPrimarySelected =
+          selectedCell?.rowIndex === rowIndex &&
+          selectedCell?.colIndex === colIndex;
+        // Determine if this cell is being edited
+        const isCurrentlyEditing =
+          editingCell?.rowIndex === rowIndex &&
+          editingCell?.colIndex === colIndex;
+        // Determine if this cell is within the general selection area
+        const isInSelectionArea = isCellSelected(rowIndex, colIndex);
+        const cellWidth = columnWidths?.[header] ?? DEFAULT_COL_WIDTH;
+
+        return (
+          <TableCell
+            key={`cell-${rowIndex}-${colIndex}`} // Added prefix to key
+            cellData={rowData[header]}
+            rowIndex={rowIndex}
+            colIndex={colIndex}
+            header={header}
+            columnWidth={cellWidth}
+            isSelected={isPrimarySelected}
+            isEditing={isCurrentlyEditing}
+            isInSelectionArea={isInSelectionArea}
+            handleCellMouseDown={handleCellMouseDown}
+            handleCellDoubleClick={handleCellDoubleClick}
+            handleCellChange={handleCellChange}
+            handleCellBlur={handleCellBlur}
+            setEditingCell={setEditingCell}
+          />
+        );
+      })}
+    </tr>
+  );
+});
+
+TableRow.displayName = 'TableRow';
+export default TableRow;


### PR DESCRIPTION
This commit introduces performance optimizations to the LiveTable component by refactoring its rendering logic. The goal is to reduce unnecessary re-renders when the selection changes, thereby improving UI responsiveness, especially for larger tables.

Key changes:
- Wrapped `LiveTableDisplay` with `React.memo`.
- Introduced a new `TableRow` component, responsible for rendering a single table row, and wrapped it with `React.memo`.
- Introduced a new `TableCell` component, responsible for rendering a single table cell, and wrapped it with `React.memo`.
- Integrated `TableRow` and `TableCell` into `LiveTableDisplay`, ensuring that props are passed down appropriately.

These changes leverage React's memoization to ensure that only the components (rows or cells) whose data or selection state has actually changed are re-rendered. This should lead to a significant reduction in the overall rendering work performed when interacting with the table, particularly during selection updates.