### PR TITLE
Fix header double click editing

### DIFF
--- a/frontend/src/__tests__/components/live-table/LiveTableHeaderEditing.test.tsx
+++ b/frontend/src/__tests__/components/live-table/LiveTableHeaderEditing.test.tsx
@@ -169,6 +169,46 @@ describe("LiveTableDisplay Header Editing", () => {
     expect(input.value).toBe(headerNameForTest);
   });
 
+  it("should enter edit mode when double-clicking the header cell", async () => {
+    const user = userEvent.setup();
+
+    const mockHandleHeaderDoubleClick = vi.fn();
+    vi.mocked(useHandleHeaderDoubleClick).mockImplementation(
+      () => mockHandleHeaderDoubleClick
+    );
+    const mockHandleHeaderChange = vi.fn();
+    vi.mocked(useHandleHeaderChange).mockImplementation(
+      () => mockHandleHeaderChange
+    );
+    const mockHandleHeaderBlur = vi.fn();
+    vi.mocked(useHandleHeaderBlur).mockImplementation(
+      () => mockHandleHeaderBlur
+    );
+
+    render(
+      <TestDataStoreWrapper liveTableDoc={liveTableDocInstance}>
+        <LiveTableDisplay />
+      </TestDataStoreWrapper>
+    );
+
+    const headerNameForTest = initialColumnDefinitions[0].name;
+
+    const thElement = screen.getAllByRole("columnheader")[1];
+    await user.dblClick(thElement);
+
+    expect(mockHandleHeaderDoubleClick).toHaveBeenCalledWith(0);
+
+    act(() => {
+      useEditingHeaderValuePush(headerNameForTest);
+      useEditingHeaderIndexPush(0);
+    });
+
+    const input = screen.getByTestId(
+      `${headerNameForTest}-editing`
+    ) as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+  });
+
   it("should update header value on input change", async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/components/live-table/LiveTableDisplay.tsx
+++ b/frontend/src/components/live-table/LiveTableDisplay.tsx
@@ -544,6 +544,11 @@ const LiveTable: React.FC = () => {
                     onDragOver={(e) => handleColumnDragOver(e, index)}
                     onDragLeave={handleColumnDragLeave}
                     onDrop={handleColumnDrop}
+                    onDoubleClick={(e) => {
+                      if (!(e.target as HTMLElement).closest(".cursor-col-resize")) {
+                        handleHeaderDoubleClick(index);
+                      }
+                    }}
                     className={`border border-slate-300 p-0 text-left relative group overflow-hidden ${
                       isDragging ? "opacity-50" : ""
                     }`}
@@ -580,9 +585,6 @@ const LiveTable: React.FC = () => {
                       ) : (
                         <div
                           className="p-2 cursor-text flex-grow break-words flex items-center"
-                          onDoubleClick={() => {
-                            handleHeaderDoubleClick(index);
-                          }}
                           style={{ cursor: "grab" }}
                           onMouseDown={(e) => {
                             // Prevent drag when clicking on resize handle


### PR DESCRIPTION
## Summary
- trigger header edit when double-clicking anywhere in the header cell
- add regression test to verify double-clicking the table header works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fcea8e37c83289d9e8bc62a428013