### PR TITLE
Fix header double click editing

### DIFF
--- a/frontend/src/__tests__/components/live-table/LiveTableHeaderEditing.test.tsx
+++ b/frontend/src/__tests__/components/live-table/LiveTableHeaderEditing.test.tsx
@@ -169,6 +169,95 @@ describe("LiveTableDisplay Header Editing", () => {
     expect(input.value).toBe(headerNameForTest);
   });
 
+  it("should enter edit mode when double-clicking the header cell", async () => {
+    const user = userEvent.setup();
+
+    const mockHandleHeaderDoubleClick = vi.fn();
+    vi.mocked(useHandleHeaderDoubleClick).mockImplementation(
+      () => mockHandleHeaderDoubleClick
+    );
+    const mockHandleHeaderChange = vi.fn();
+    vi.mocked(useHandleHeaderChange).mockImplementation(
+      () => mockHandleHeaderChange
+    );
+    const mockHandleHeaderBlur = vi.fn();
+    vi.mocked(useHandleHeaderBlur).mockImplementation(
+      () => mockHandleHeaderBlur
+    );
+
+    render(
+      <TestDataStoreWrapper liveTableDoc={liveTableDocInstance}>
+        <LiveTableDisplay />
+      </TestDataStoreWrapper>
+    );
+
+    const headerNameForTest = initialColumnDefinitions[0].name;
+
+    const thElement = screen.getAllByRole("columnheader")[1];
+    await user.dblClick(thElement);
+
+    expect(mockHandleHeaderDoubleClick).toHaveBeenCalledWith(0);
+
+    act(() => {
+      useEditingHeaderValuePush(headerNameForTest);
+      useEditingHeaderIndexPush(0);
+    });
+
+    const input = screen.getByTestId(
+      `${headerNameForTest}-editing`
+    ) as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+  });
+
+  it("should enter edit mode when double tapping the header cell", async () => {
+    const user = userEvent.setup();
+
+    const mockHandleHeaderDoubleClick = vi.fn();
+    vi.mocked(useHandleHeaderDoubleClick).mockImplementation(
+      () => mockHandleHeaderDoubleClick
+    );
+    const mockHandleHeaderChange = vi.fn();
+    vi.mocked(useHandleHeaderChange).mockImplementation(
+      () => mockHandleHeaderChange
+    );
+    const mockHandleHeaderBlur = vi.fn();
+    vi.mocked(useHandleHeaderBlur).mockImplementation(
+      () => mockHandleHeaderBlur
+    );
+
+    render(
+      <TestDataStoreWrapper liveTableDoc={liveTableDocInstance}>
+        <LiveTableDisplay />
+      </TestDataStoreWrapper>
+    );
+
+    const headerNameForTest = initialColumnDefinitions[0].name;
+
+    const thElement = screen.getAllByRole("columnheader")[1];
+
+    const nowSpy = vi
+      .spyOn(Date, "now")
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(100);
+
+    fireEvent.touchStart(thElement);
+    fireEvent.touchStart(thElement);
+
+    nowSpy.mockRestore();
+
+    expect(mockHandleHeaderDoubleClick).toHaveBeenCalledWith(0);
+
+    act(() => {
+      useEditingHeaderValuePush(headerNameForTest);
+      useEditingHeaderIndexPush(0);
+    });
+
+    const input = screen.getByTestId(
+      `${headerNameForTest}-editing`
+    ) as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+  });
+
   it("should update header value on input change", async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/components/live-table/LiveTableDisplay.tsx
+++ b/frontend/src/components/live-table/LiveTableDisplay.tsx
@@ -92,6 +92,20 @@ const LiveTable: React.FC = () => {
     null
   );
   const tableRef = useRef<HTMLTableElement>(null);
+  const lastHeaderTouch = useRef(0);
+
+  const handleHeaderTouchStart = useCallback(
+    (event: React.TouchEvent, colIndex: number) => {
+      const now = Date.now();
+      if (now - lastHeaderTouch.current < 300) {
+        if (!(event.target as HTMLElement).closest(".cursor-col-resize")) {
+          handleHeaderDoubleClick(colIndex);
+        }
+      }
+      lastHeaderTouch.current = now;
+    },
+    [handleHeaderDoubleClick]
+  );
 
   const handleColumnDragStart = useCallback(
     (event: React.DragEvent, columnIndex: number) => {
@@ -544,6 +558,12 @@ const LiveTable: React.FC = () => {
                     onDragOver={(e) => handleColumnDragOver(e, index)}
                     onDragLeave={handleColumnDragLeave}
                     onDrop={handleColumnDrop}
+                    onDoubleClick={(e) => {
+                      if (!(e.target as HTMLElement).closest(".cursor-col-resize")) {
+                        handleHeaderDoubleClick(index);
+                      }
+                    }}
+                    onTouchStart={(e) => handleHeaderTouchStart(e, index)}
                     className={`border border-slate-300 p-0 text-left relative group overflow-hidden ${
                       isDragging ? "opacity-50" : ""
                     }`}
@@ -580,9 +600,6 @@ const LiveTable: React.FC = () => {
                       ) : (
                         <div
                           className="p-2 cursor-text flex-grow break-words flex items-center"
-                          onDoubleClick={() => {
-                            handleHeaderDoubleClick(index);
-                          }}
                           style={{ cursor: "grab" }}
                           onMouseDown={(e) => {
                             // Prevent drag when clicking on resize handle


### PR DESCRIPTION
## Summary
- trigger header edit when double-clicking anywhere in the header cell
- add regression test to verify double-clicking the table header works
- support editing via double tap on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fcea8e37c83289d9e8bc62a428013