### PR TITLE
Adjust headers for live table pages

### DIFF
--- a/frontend/src/app/(main)/document/[docId]/document-page-client.tsx
+++ b/frontend/src/app/(main)/document/[docId]/document-page-client.tsx
@@ -68,6 +68,7 @@ export default function DocumentPageClient({
         title={pageTitle}
         description={pageDescription}
         onUpdate={handleUpdate}
+        className="fixed top-3 left-24 right-24 z-20"
       />
       <LiveTable
         tableId={document.liveblocks_id}

--- a/frontend/src/app/(main)/moons/page.tsx
+++ b/frontend/src/app/(main)/moons/page.tsx
@@ -7,7 +7,11 @@ export default function Moons() {
   const pageDescription = "Here is a list of the moons orbiting our planets.";
   return (
     <Container>
-      <FlexTitle title={pageTitle} description={pageDescription} />
+      <FlexTitle
+        title={pageTitle}
+        description={pageDescription}
+        className="fixed top-3 left-24 right-24 z-20 !mt-0"
+      />
       <LiveTable
         tableId="moons"
         documentTitle={pageTitle}

--- a/frontend/src/app/(main)/planets/page.tsx
+++ b/frontend/src/app/(main)/planets/page.tsx
@@ -18,7 +18,11 @@ export default function Planets() {
       >
         Next: some moons
       </InternalLink>
-      <FlexTitle title={pageTitle} description={pageDescription} />
+      <FlexTitle
+        title={pageTitle}
+        description={pageDescription}
+        className="fixed top-3 left-24 right-24 z-20 !mt-0"
+      />
       <LiveTable
         tableId="planet-editor"
         documentTitle={pageTitle}

--- a/frontend/src/components/editable-flex-title.tsx
+++ b/frontend/src/components/editable-flex-title.tsx
@@ -29,12 +29,14 @@ interface EditableFlexTitleProps {
     title?: string;
     description?: string;
   }) => Promise<void>;
+  className?: string;
 }
 
 export default function EditableFlexTitle({
   title,
   description,
   onUpdate,
+  className,
 }: EditableFlexTitleProps) {
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [isEditingDescription, setIsEditingDescription] = useState(false);
@@ -126,7 +128,12 @@ export default function EditableFlexTitle({
   };
 
   return (
-    <div className="mt-14 w-full flex items-center justify-start space-x-2">
+    <div
+      className={
+        "mt-14 w-full flex items-center justify-start space-x-2 " +
+        (className ?? "")
+      }
+    >
       {isEditingTitle ? (
         <div className="flex items-center space-x-2 flex-1">
           <Input

--- a/frontend/src/components/flex-title.tsx
+++ b/frontend/src/components/flex-title.tsx
@@ -13,12 +13,19 @@ import {
 export default function FlexTitle({
   title,
   description,
+  className,
 }: {
   title: string;
   description: string;
+  className?: string;
 }) {
   return (
-    <div className="mt-14 w-full flex items-center justify-start space-x-2">
+    <div
+      className={
+        "mt-14 w-full flex items-center justify-start space-x-2 " +
+        (className ?? "")
+      }
+    >
       <h2 className="text-2xl font-bold truncate min-w-0" title={title}>
         {title}
       </h2>

--- a/frontend/src/components/live-table/LiveTableContainer.tsx
+++ b/frontend/src/components/live-table/LiveTableContainer.tsx
@@ -8,7 +8,7 @@ const LiveTableContainer: React.FC<LiveTableContainerProps> = ({
   children,
 }) => {
   return (
-    <div className="fixed flex flex-col bottom-0 left-0 right-0 h-[calc(100dvh-110px-env(safe-area-inset-top,0px))] p-1 z-10 bg-background">
+    <div className="fixed flex flex-col bottom-0 left-0 right-0 h-[calc(100dvh-80px-env(safe-area-inset-top,0px))] p-1 z-10 bg-background">
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary
- allow customizing flex title components
- position titles next to the menu button on moons, planets and documents pages
- increase live table height so it fills more of the screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fb4b6d9e08328ac155ac2e2a18879