### PR TITLE
Add blank row dropdown

### DIFF
--- a/frontend/src/__tests__/components/live-table/LiveTableToolbar.test.tsx
+++ b/frontend/src/__tests__/components/live-table/LiveTableToolbar.test.tsx
@@ -14,6 +14,7 @@ import {
   render,
   screen,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import generateNewColumns
   from "@/components/live-table/actions/generateNewColumns";
@@ -401,7 +402,7 @@ describe("LiveTableToolbar - Add Row Buttons", () => {
     vi.mocked(useLiveTable).mockReturnValue(mockData);
 
     render(<LiveTableToolbar />);
-    const button = screen.getByRole("button", { name: "Add Row Below" });
+    const button = screen.getByRole("button", { name: "Add Row Below (AI)" });
     await act(async () => {
       fireEvent.mouseDown(button);
       await vi.runAllTimersAsync();
@@ -471,7 +472,7 @@ describe("LiveTableToolbar - Add Row Buttons", () => {
     vi.mocked(useSelectedCells).mockReturnValue(selectedCellsData);
 
     render(<LiveTableToolbar />);
-    const button = screen.getByRole("button", { name: "Add 3 Rows Below" });
+    const button = screen.getByRole("button", { name: "Add 3 Rows Below (AI)" });
     await act(async () => {
       fireEvent.mouseDown(button);
       await vi.runAllTimersAsync();
@@ -504,6 +505,13 @@ describe("LiveTableToolbar - Add Row Buttons", () => {
 
     expect(mockGenerateAndInsertRows).toHaveBeenCalledTimes(1);
     expect(mockGenerateAndInsertRows).toHaveBeenCalledWith(0, 1);
+  });
+
+  it("renders row options dropdown", () => {
+    render(<LiveTableToolbar />);
+    expect(
+      screen.getByRole("button", { name: "Row Options" })
+    ).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/__tests__/components/live-table/liveTableTestUtils.tsx
+++ b/frontend/src/__tests__/components/live-table/liveTableTestUtils.tsx
@@ -152,6 +152,7 @@ export const getLiveTableMockValues = (
     generateAndInsertRows: vi
       .fn()
       .mockResolvedValue({ aiRowsAdded: 0, defaultRowsAdded: 0 }),
+    insertBlankRows: vi.fn().mockResolvedValue({ insertedCount: 0 }),
     deleteRows: vi.fn().mockResolvedValue({ deletedCount: 0 }),
     generateAndInsertColumns: vi
       .fn()


### PR DESCRIPTION
## Summary
- support inserting blank rows in LiveTableProvider
- expose blank row method in toolbar
- add dropdown with AI and blank options for creating rows
- update tests for new dropdown

## Testing
- `npx vitest run src/__tests__/components/live-table/LiveTableToolbar.test.tsx`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6840c3d4a39883288aaabe56c875d715