### PR TITLE
Enable mobile double-tap editing

### DIFF
--- a/frontend/src/__tests__/components/editable-flex-title.test.tsx
+++ b/frontend/src/__tests__/components/editable-flex-title.test.tsx
@@ -54,6 +54,16 @@ describe("EditableFlexTitle", () => {
     expect(screen.getByRole("button", { name: /cancel editing/i })).toBeInTheDocument();
   });
 
+  it("should enter edit mode when title is double clicked", async () => {
+    const user = userEvent.setup();
+    render(<EditableFlexTitle {...defaultProps} />);
+
+    const title = screen.getByText("Test Document");
+    await user.dblClick(title);
+
+    expect(screen.getByDisplayValue("Test Document")).toBeInTheDocument();
+  });
+
   it("should save title changes when save button is clicked", async () => {
     const user = userEvent.setup();
     mockOnUpdate.mockResolvedValue(undefined);

--- a/frontend/src/__tests__/components/live-table/LiveTableHeaderEditing.test.tsx
+++ b/frontend/src/__tests__/components/live-table/LiveTableHeaderEditing.test.tsx
@@ -169,6 +169,51 @@ describe("LiveTableDisplay Header Editing", () => {
     expect(input.value).toBe(headerNameForTest);
   });
 
+  it("should enter edit mode on header double-tap and display input", async () => {
+    vi.useFakeTimers();
+
+    const mockHandleHeaderDoubleClick = vi.fn();
+    vi.mocked(useHandleHeaderDoubleClick).mockImplementation(
+      () => mockHandleHeaderDoubleClick
+    );
+    const mockHandleHeaderChange = vi.fn();
+    vi.mocked(useHandleHeaderChange).mockImplementation(
+      () => mockHandleHeaderChange
+    );
+    const mockHandleHeaderBlur = vi.fn();
+    vi.mocked(useHandleHeaderBlur).mockImplementation(
+      () => mockHandleHeaderBlur
+    );
+
+    render(
+      <TestDataStoreWrapper liveTableDoc={liveTableDocInstance}>
+        <LiveTableDisplay />
+      </TestDataStoreWrapper>
+    );
+
+    const headerNameForTest = initialColumnDefinitions[0].name;
+
+    const headerCellDiv = screen.getByText(headerNameForTest).closest("div")!;
+    fireEvent.touchStart(headerCellDiv);
+    vi.advanceTimersByTime(100);
+    fireEvent.touchStart(headerCellDiv);
+    vi.runAllTimers();
+
+    expect(mockHandleHeaderDoubleClick).toHaveBeenCalledWith(0);
+
+    act(() => {
+      useEditingHeaderValuePush(headerNameForTest);
+      useEditingHeaderIndexPush(0);
+    });
+
+    const input = screen.getByTestId(
+      `${headerNameForTest}-editing`
+    ) as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe(headerNameForTest);
+    vi.useRealTimers();
+  });
+
   it("should update header value on input change", async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/components/editable-flex-title.tsx
+++ b/frontend/src/components/editable-flex-title.tsx
@@ -160,7 +160,11 @@ export default function EditableFlexTitle({
         </div>
       ) : (
         <div className="flex items-center space-x-2 flex-1">
-          <h2 className="text-2xl font-bold truncate min-w-0" title={title}>
+          <h2
+            className="text-2xl font-bold truncate min-w-0"
+            title={title}
+            onDoubleClick={handleTitleEdit}
+          >
             {title}
           </h2>
           <Button

--- a/frontend/src/components/live-table/LiveTableDisplay.tsx
+++ b/frontend/src/components/live-table/LiveTableDisplay.tsx
@@ -117,6 +117,36 @@ const LiveTable: React.FC = () => {
     }
   }, []);
 
+  const lastHeaderTapRef = useRef<{ time: number; index: number } | null>(null);
+  const headerTapTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleHeaderTouchStart = useCallback(
+    (index: number) => {
+      const now = Date.now();
+      if (
+        lastHeaderTapRef.current &&
+        now - lastHeaderTapRef.current.time < 300 &&
+        lastHeaderTapRef.current.index === index
+      ) {
+        if (headerTapTimeoutRef.current) {
+          clearTimeout(headerTapTimeoutRef.current);
+          headerTapTimeoutRef.current = null;
+        }
+        lastHeaderTapRef.current = null;
+        handleHeaderDoubleClick(index);
+      } else {
+        lastHeaderTapRef.current = { time: now, index };
+        if (headerTapTimeoutRef.current) {
+          clearTimeout(headerTapTimeoutRef.current);
+        }
+        headerTapTimeoutRef.current = setTimeout(() => {
+          lastHeaderTapRef.current = null;
+        }, 300);
+      }
+    },
+    [handleHeaderDoubleClick]
+  );
+
   const handleColumnDragOver = useCallback(
     (event: React.DragEvent, columnIndex: number) => {
       event.preventDefault();
@@ -583,6 +613,7 @@ const LiveTable: React.FC = () => {
                           onDoubleClick={() => {
                             handleHeaderDoubleClick(index);
                           }}
+                          onTouchStart={() => handleHeaderTouchStart(index)}
                           style={{ cursor: "grab" }}
                           onMouseDown={(e) => {
                             // Prevent drag when clicking on resize handle


### PR DESCRIPTION
## Summary
- make the `EditableFlexTitle` header editable via double-tap
- test that double-clicking the title enters edit mode

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840ca84e7188328946efadcb2170cc8