### PR TITLE
Move generateAndInsertColumns to dataStore

### DIFF
--- a/frontend/src/__tests__/components/live-table/LiveTableColumnReorder.test.tsx
+++ b/frontend/src/__tests__/components/live-table/LiveTableColumnReorder.test.tsx
@@ -1,18 +1,7 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
 
-import {
-  fireEvent,
-  render,
-  screen,
-} from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 import LiveTableDisplay from "@/components/live-table/LiveTableDisplay";
 import { LiveTableDoc } from "@/components/live-table/LiveTableDoc";
@@ -54,7 +43,6 @@ const mockLiveTableContext: LiveTableContextType = {
   },
   isTableLoaded: true,
   deleteRows: vi.fn(),
-  generateAndInsertColumns: vi.fn(),
   deleteColumns: vi.fn(),
   reorderColumn: vi.fn(),
   awarenessStates: new Map(),
@@ -67,7 +55,7 @@ vi.mock(
   async (importOriginal) => ({
     ...(await importOriginal()),
     useLiveTable: vi.fn(),
-  })
+  }),
 );
 
 vi.mock("@/stores/selectionStore", async (importOriginal) => ({
@@ -144,7 +132,7 @@ describe("LiveTableDisplay - Column Reordering", () => {
     render(
       <TestDataStoreWrapper liveTableDoc={liveTableDocInstance}>
         <LiveTableDisplay />
-      </TestDataStoreWrapper>
+      </TestDataStoreWrapper>,
     );
 
     const columnAHeader = screen.getByText("Column A").closest("th");
@@ -158,7 +146,7 @@ describe("LiveTableDisplay - Column Reordering", () => {
     render(
       <TestDataStoreWrapper liveTableDoc={liveTableDocInstance}>
         <LiveTableDisplay />
-      </TestDataStoreWrapper>
+      </TestDataStoreWrapper>,
     );
 
     // Verify that the reorderColumn function is available and is a function
@@ -170,7 +158,7 @@ describe("LiveTableDisplay - Column Reordering", () => {
     render(
       <TestDataStoreWrapper liveTableDoc={liveTableDocInstance}>
         <LiveTableDisplay />
-      </TestDataStoreWrapper>
+      </TestDataStoreWrapper>,
     );
 
     const columnAHeader = screen.getByText("Column A").closest("th");
@@ -183,7 +171,7 @@ describe("LiveTableDisplay - Column Reordering", () => {
     render(
       <TestDataStoreWrapper liveTableDoc={liveTableDocInstance}>
         <LiveTableDisplay />
-      </TestDataStoreWrapper>
+      </TestDataStoreWrapper>,
     );
 
     const columnAHeader = screen
@@ -204,7 +192,7 @@ describe("LiveTableDisplay - Column Reordering", () => {
     // Simulate drag over Column C (should set insert position)
     const columnCRect = { left: 300, width: 150, right: 450 };
     vi.spyOn(columnCHeader, "getBoundingClientRect").mockReturnValue(
-      columnCRect as DOMRect
+      columnCRect as DOMRect,
     );
 
     fireEvent.dragOver(columnCHeader, {

--- a/frontend/src/__tests__/components/live-table/liveTableTestUtils.tsx
+++ b/frontend/src/__tests__/components/live-table/liveTableTestUtils.tsx
@@ -11,9 +11,7 @@ import type {
   ColumnId,
   RowId,
 } from "@/components/live-table/LiveTableDoc";
-import {
-  LiveTableDoc,
-} from "@/components/live-table/LiveTableDoc"; // Import the actual LiveTableDoc
+import { LiveTableDoc } from "@/components/live-table/LiveTableDoc"; // Import the actual LiveTableDoc
 import * as LiveTableProvider from "@/components/live-table/LiveTableProvider";
 import { DataStoreProvider } from "@/stores/dataStore";
 
@@ -45,7 +43,7 @@ export interface LiveTableMockOverrides
 }
 
 export const getLiveTableMockValues = (
-  overrides: LiveTableMockOverrides = {}
+  overrides: LiveTableMockOverrides = {},
 ) => {
   let liveTableDoc: LiveTableDoc;
   let yDoc: Y.Doc;
@@ -93,7 +91,7 @@ export const getLiveTableMockValues = (
           liveTableDoc.yColumnOrder.push(overrides.initialColumnOrder);
         } else if (overrides.initialColumnDefinitions) {
           liveTableDoc.yColumnOrder.push(
-            overrides.initialColumnDefinitions.map((d) => d.id)
+            overrides.initialColumnDefinitions.map((d) => d.id),
           );
         }
 
@@ -105,7 +103,7 @@ export const getLiveTableMockValues = (
             liveTableDoc.yRowOrder.push(overrides.initialRowOrder);
           } else {
             liveTableDoc.yRowOrder.push(
-              Object.keys(overrides.initialRowData) as RowId[]
+              Object.keys(overrides.initialRowData) as RowId[],
             );
           }
 
@@ -150,9 +148,6 @@ export const getLiveTableMockValues = (
     headers: currentHeaders,
     columnWidths: currentColWidths,
     deleteRows: vi.fn().mockResolvedValue({ deletedCount: 0 }),
-    generateAndInsertColumns: vi
-      .fn()
-      .mockResolvedValue({ aiColsAdded: 0, defaultColsAdded: 0 }),
     deleteColumns: vi.fn().mockResolvedValue({ deletedCount: 0 }),
     reorderColumn: vi.fn(),
     // awareness
@@ -189,7 +184,7 @@ export const TestDataStoreWrapper: React.FC<{
       },
       getYDoc: vi.fn(() => defaultDoc.yDoc),
     }),
-    [defaultDoc]
+    [defaultDoc],
   );
 
   return (

--- a/frontend/src/components/live-table/LiveTableToolbar.tsx
+++ b/frontend/src/components/live-table/LiveTableToolbar.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/components/ui/tooltip";
 import {
   useGenerateAndInsertRows,
+  useGenerateAndInsertColumns,
   useIsCellLocked,
   useUndoManager,
 } from "@/stores/dataStore";
@@ -110,20 +111,15 @@ const ESTIMATED_WIDTHS: Record<string, number> = {
 };
 
 const LiveTableToolbar: React.FC = () => {
-  const {
-    isTableLoaded,
-    deleteRows,
-    generateAndInsertColumns,
-    deleteColumns,
-    headers,
-    tableData,
-  } = useLiveTable();
+  const { isTableLoaded, deleteRows, deleteColumns, headers, tableData } =
+    useLiveTable();
 
   const isCellLocked = useIsCellLocked();
   const undoManager = useUndoManager();
   const selectedCell = useSelectedCell();
   const selectedCells = useSelectedCells();
   const generateAndInsertRows = useGenerateAndInsertRows();
+  const generateAndInsertColumns = useGenerateAndInsertColumns();
 
   const [isPending, startTransition] = useTransition();
   const [pendingOperation, setPendingOperation] =
@@ -174,7 +170,7 @@ const LiveTableToolbar: React.FC = () => {
       return false;
     }
     return selectedCells.some((cell) =>
-      isCellLocked(cell.rowIndex, cell.colIndex)
+      isCellLocked(cell.rowIndex, cell.colIndex),
     );
   }, [selectedCells, selectedCell, isCellLocked]);
 
@@ -218,13 +214,13 @@ const LiveTableToolbar: React.FC = () => {
       } else {
         // Table has columns, rows, but no cell selected
         toast.info(
-          "Please select a cell to add rows relative to, or the table must be empty of rows."
+          "Please select a cell to add rows relative to, or the table must be empty of rows.",
         );
         return;
       }
 
       setPendingOperation(
-        direction === "above" ? "add-row-above" : "add-row-below"
+        direction === "above" ? "add-row-above" : "add-row-below",
       );
 
       startTransition(async () => {
@@ -233,10 +229,10 @@ const LiveTableToolbar: React.FC = () => {
         } catch (error) {
           console.error(
             `Critical error in handleAddRowRelative transition:`,
-            error
+            error,
           );
           toast.error(
-            "A critical error occurred while preparing to add rows. Please try again."
+            "A critical error occurred while preparing to add rows. Please try again.",
           );
         } finally {
           setPendingOperation(null);
@@ -251,12 +247,12 @@ const LiveTableToolbar: React.FC = () => {
       selectedCell,
       getSelectedRowIndices,
       generateAndInsertRows,
-    ]
+    ],
   );
 
   const handleDeleteRows = useCallback(() => {
     const uniqueRowIndicesToDelete = getSelectedRowIndices().sort(
-      (a, b) => b - a
+      (a, b) => b - a,
     );
 
     if (uniqueRowIndicesToDelete.length === 0) {
@@ -269,7 +265,7 @@ const LiveTableToolbar: React.FC = () => {
       } catch (error) {
         console.error("Critical error in handleDeleteRows transition:", error);
         toast.error(
-          "A critical error occurred while preparing to delete rows. Please try again."
+          "A critical error occurred while preparing to delete rows. Please try again.",
         );
       }
     });
@@ -317,7 +313,7 @@ const LiveTableToolbar: React.FC = () => {
       }
 
       setPendingOperation(
-        direction === "left" ? "add-column-left" : "add-column-right"
+        direction === "left" ? "add-column-left" : "add-column-right",
       );
 
       startTransition(async () => {
@@ -326,10 +322,10 @@ const LiveTableToolbar: React.FC = () => {
         } catch (error) {
           console.error(
             "Critical error in handleAddColumnRelative transition:",
-            error
+            error,
           );
           toast.error(
-            "A critical error occurred while preparing to add columns. Please try again."
+            "A critical error occurred while preparing to add columns. Please try again.",
           );
         } finally {
           setPendingOperation(null);
@@ -344,12 +340,12 @@ const LiveTableToolbar: React.FC = () => {
       getUniqueSelectedColumnIndices,
       selectedCells,
       generateAndInsertColumns,
-    ]
+    ],
   );
 
   const handleDeleteColumns = useCallback(() => {
     const uniqueColIndicesToDelete = getUniqueSelectedColumnIndices().sort(
-      (a, b) => b - a
+      (a, b) => b - a,
     );
 
     if (uniqueColIndicesToDelete.length === 0) {
@@ -362,10 +358,10 @@ const LiveTableToolbar: React.FC = () => {
       } catch (error) {
         console.error(
           "Critical error in handleDeleteColumns transition:",
-          error
+          error,
         );
         toast.error(
-          "A critical error occurred while preparing to delete columns. Please try again."
+          "A critical error occurred while preparing to delete columns. Please try again.",
         );
       }
     });
@@ -634,7 +630,7 @@ const LiveTableToolbar: React.FC = () => {
       handleAddColumnRelative,
       handleDeleteColumns,
       handleDownloadCsv,
-    ]
+    ],
   );
 
   // Calculate which buttons should be visible
@@ -913,7 +909,7 @@ const LiveTableToolbar: React.FC = () => {
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 {BUTTON_ORDER.filter(
-                  (buttonId) => !visibleButtonIds.includes(buttonId)
+                  (buttonId) => !visibleButtonIds.includes(buttonId),
                 ).map((buttonId) => renderButton(buttonId, true))}
               </DropdownMenuContent>
             </DropdownMenu>

--- a/frontend/src/components/live-table/manage-columns.ts
+++ b/frontend/src/components/live-table/manage-columns.ts
@@ -1,0 +1,162 @@
+import { toast } from "sonner";
+
+import generateNewColumns, {
+  GeneratedColumn,
+} from "./actions/generateNewColumns";
+import { LiveTableDoc } from "./LiveTableDoc";
+
+export async function generateAndInsertColumns(
+  initialInsertIndex: number,
+  numColsToAdd: number,
+  headers: string[],
+  tableData: Record<string, unknown>[],
+  documentTitle: string,
+  documentDescription: string,
+  liveTableDoc: LiveTableDoc,
+) {
+  if (numColsToAdd <= 0) {
+    toast.info("No columns were added as the number to add was zero.");
+    return { aiColsAdded: 0, defaultColsAdded: 0 };
+  }
+  if (!headers || !tableData) {
+    throw new Error("Cannot add columns: table headers or data not loaded.");
+  }
+
+  const currentTableDataForAi = tableData.map((row) => ({ ...row }));
+  const currentHeadersForAi = [...headers];
+  let aiColsAddedCount = 0;
+  let defaultColsAddedCount = 0;
+  const columnsToInsert: {
+    headerName: string;
+    columnData: (string | null)[] | null;
+  }[] = [];
+
+  try {
+    const result = await generateNewColumns(
+      currentTableDataForAi,
+      currentHeadersForAi,
+      numColsToAdd,
+      documentTitle,
+      documentDescription,
+    );
+
+    if (result.error) {
+      for (let i = 0; i < numColsToAdd; i++) {
+        columnsToInsert.push({
+          headerName: generateUniqueDefaultHeader(
+            "New Column",
+            currentHeadersForAi,
+            columnsToInsert,
+          ),
+          columnData: null,
+        });
+        defaultColsAddedCount++;
+      }
+    } else if (
+      !result.generatedColumns ||
+      result.generatedColumns.length === 0
+    ) {
+      for (let i = 0; i < numColsToAdd; i++) {
+        columnsToInsert.push({
+          headerName: generateUniqueDefaultHeader(
+            "New Column",
+            currentHeadersForAi,
+            columnsToInsert,
+          ),
+          columnData: null,
+        });
+        defaultColsAddedCount++;
+      }
+    } else {
+      result.generatedColumns.forEach((col: GeneratedColumn) => {
+        columnsToInsert.push({
+          headerName: col.headerName,
+          columnData: col.columnData,
+        });
+        aiColsAddedCount++;
+      });
+      const remainingColsToFill = numColsToAdd - aiColsAddedCount;
+      for (let i = 0; i < remainingColsToFill; i++) {
+        columnsToInsert.push({
+          headerName: generateUniqueDefaultHeader(
+            "New Column",
+            currentHeadersForAi,
+            columnsToInsert,
+          ),
+          columnData: null,
+        });
+        defaultColsAddedCount++;
+      }
+    }
+
+    if (columnsToInsert.length === 0 && numColsToAdd > 0) {
+      toast.info("Attempted to add columns, but no columns were prepared.");
+      return { aiColsAdded: 0, defaultColsAdded: 0 };
+    }
+
+    if (columnsToInsert.length > 0) {
+      liveTableDoc.insertColumns(initialInsertIndex, columnsToInsert);
+    }
+
+    if (result.error) {
+      toast.error(
+        `AI column generation failed: ${result.error}. Added ${defaultColsAddedCount} default column(s).`,
+      );
+    } else if (aiColsAddedCount > 0 && defaultColsAddedCount === 0) {
+      toast.success(
+        `Successfully added ${aiColsAddedCount} AI-suggested column(s).`,
+      );
+    } else if (aiColsAddedCount > 0 && defaultColsAddedCount > 0) {
+      toast.info(
+        `Added ${numColsToAdd} column(s): ${aiColsAddedCount} AI-suggested, ${defaultColsAddedCount} default.`,
+      );
+    } else if (defaultColsAddedCount > 0 && aiColsAddedCount === 0) {
+      toast.info(
+        `Added ${defaultColsAddedCount} default column(s) as AI suggestions were not available or an issue occurred.`,
+      );
+    }
+
+    return {
+      aiColsAdded: aiColsAddedCount,
+      defaultColsAdded: defaultColsAddedCount,
+    };
+  } catch (error) {
+    const fallbackColumns: { headerName: string; columnData: null }[] = [];
+    for (let i = 0; i < numColsToAdd; i++) {
+      fallbackColumns.push({
+        headerName: generateUniqueDefaultHeader(
+          "New Column",
+          currentHeadersForAi,
+          fallbackColumns,
+        ),
+        columnData: null,
+      });
+    }
+    if (fallbackColumns.length > 0) {
+      try {
+        liveTableDoc.insertColumns(initialInsertIndex, fallbackColumns);
+      } catch {
+        // ignore nested errors and rethrow the original
+      }
+    }
+    throw error instanceof Error ? error : new Error(String(error));
+  }
+}
+
+function generateUniqueDefaultHeader(
+  base: string,
+  existingHeaders: string[],
+  columnsToInsert: { headerName: string }[],
+): string {
+  let counter = 1;
+  let name = `${base} ${counter}`;
+  const allHeaders = [
+    ...existingHeaders.map((h) => h.toLowerCase()),
+    ...columnsToInsert.map((c) => c.headerName.toLowerCase()),
+  ];
+  while (allHeaders.includes(name.toLowerCase())) {
+    counter++;
+    name = `${base} ${counter}`;
+  }
+  return name;
+}


### PR DESCRIPTION
## Summary
- move generateAndInsertColumns into dataStore
- update hooks and provider usage
- adjust tests for new hook location

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840dc2ab69c8328b52482e53a333750