### PR TITLE
Implement row/column header selection

### DIFF
--- a/frontend/src/__tests__/components/live-table/LiveTableHeaderClickSelection.test.tsx
+++ b/frontend/src/__tests__/components/live-table/LiveTableHeaderClickSelection.test.tsx
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import LiveTableDisplay from "@/components/live-table/LiveTableDisplay";
+import { useHeaders, useIsTableLoaded, useTableData } from "@/stores/dataStore";
+import { useSetSelectionRange } from "@/stores/selectionStore";
+import { TestDataStoreWrapper } from "./data-store-test-utils";
+
+vi.mock("@/stores/dataStore", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useIsTableLoaded: vi.fn(),
+  useHeaders: vi.fn(),
+  useTableData: vi.fn(),
+}));
+
+vi.mock("@/stores/selectionStore", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useSetSelectionRange: vi.fn(),
+}));
+
+describe("LiveTableDisplay - Header Click Selection", () => {
+  const headers = ["A", "B"];
+  const data = [
+    { A: "1", B: "2" },
+    { A: "3", B: "4" },
+  ];
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(useIsTableLoaded).mockReturnValue(true);
+    vi.mocked(useHeaders).mockReturnValue(headers);
+    vi.mocked(useTableData).mockReturnValue(data);
+  });
+
+  it("selects entire column when header clicked", () => {
+    const mockSetRange = vi.fn();
+    vi.mocked(useSetSelectionRange).mockReturnValue(mockSetRange);
+
+    render(
+      <TestDataStoreWrapper>
+        <LiveTableDisplay />
+      </TestDataStoreWrapper>
+    );
+
+    const headerEl = screen.getByText("A").closest("th") as HTMLElement;
+    fireEvent.click(headerEl);
+
+    expect(mockSetRange).toHaveBeenCalledWith(
+      { rowIndex: 0, colIndex: 0 },
+      { rowIndex: data.length - 1, colIndex: 0 }
+    );
+  });
+
+  it("selects entire row when row header clicked", () => {
+    const mockSetRange = vi.fn();
+    vi.mocked(useSetSelectionRange).mockReturnValue(mockSetRange);
+
+    render(
+      <TestDataStoreWrapper>
+        <LiveTableDisplay />
+      </TestDataStoreWrapper>
+    );
+
+    const rowHeader = screen.getAllByTestId("row-number")[1];
+    fireEvent.click(rowHeader);
+
+    expect(mockSetRange).toHaveBeenCalledWith(
+      { rowIndex: 1, colIndex: 0 },
+      { rowIndex: 1, colIndex: headers.length - 1 }
+    );
+  });
+});

--- a/frontend/src/components/live-table/LiveTableDisplay.tsx
+++ b/frontend/src/components/live-table/LiveTableDisplay.tsx
@@ -30,6 +30,7 @@ import {
 
 import { DelayedLoadingSpinner } from "../ui/loading";
 import TableCell from "./TableCell";
+import { useSetSelectionRange } from "@/stores/selectionStore";
 
 export interface CursorInfo {
   user?: { name: string; color: string };
@@ -61,6 +62,7 @@ const LiveTable: React.FC = () => {
   const setTableRef = useSetTableRef();
 
   const reorderColumn = useReorderColumn();
+  const setSelectionRange = useSetSelectionRange();
 
   const [resizingHeader, setResizingHeader] = useState<string | null>(null);
   const [startX, setStartX] = useState(0);
@@ -263,6 +265,30 @@ const LiveTable: React.FC = () => {
     [handleHeaderBlur, setEditingHeaderIndex]
   );
 
+  const handleColumnHeaderClick = useCallback(
+    (colIndex: number) => {
+      if (!headers || !tableData || tableData.length === 0) return;
+      const lastRowIndex = tableData.length - 1;
+      setSelectionRange(
+        { rowIndex: 0, colIndex },
+        { rowIndex: lastRowIndex, colIndex }
+      );
+    },
+    [headers, tableData, setSelectionRange]
+  );
+
+  const handleRowHeaderClick = useCallback(
+    (rowIndex: number) => {
+      if (!headers || headers.length === 0) return;
+      const lastColIndex = headers.length - 1;
+      setSelectionRange(
+        { rowIndex, colIndex: 0 },
+        { rowIndex, colIndex: lastColIndex }
+      );
+    },
+    [headers, setSelectionRange]
+  );
+
   if (!isTableLoaded) {
     return <DelayedLoadingSpinner />;
   }
@@ -344,6 +370,7 @@ const LiveTable: React.FC = () => {
                     onDragOver={(e) => handleColumnDragOver(e, index)}
                     onDragLeave={handleColumnDragLeave}
                     onDrop={handleColumnDrop}
+                    onClick={() => handleColumnHeaderClick(index)}
                     className={`border border-slate-300 p-0 text-left relative group overflow-hidden ${
                       isDragging ? "opacity-50" : ""
                     }`}
@@ -469,6 +496,7 @@ const LiveTable: React.FC = () => {
                     maxWidth: `${ROW_NUMBER_COL_WIDTH}px`,
                   }}
                   data-testid="row-number"
+                  onClick={() => handleRowHeaderClick(rowIndex)}
                 >
                   <div className="p-2 h-full flex items-center justify-center">
                     {rowIndex + 1}

--- a/frontend/src/stores/selectionStore.ts
+++ b/frontend/src/stores/selectionStore.ts
@@ -18,6 +18,7 @@ export interface SelectionState {
   // true if the user is currently dragging to select cells
   isSelecting: boolean;
   setSelectedCell: (cell: CellPosition | null) => void;
+  setSelectionRange: (start: CellPosition, end: CellPosition) => void;
   startOrMoveSelection: (
     rowIndex: number,
     colIndex: number,
@@ -39,6 +40,12 @@ const initialState: Pick<
 export const selectionStore = createStore<SelectionState>((set, get) => ({
   ...initialState,
   setSelectedCell: (cell) => set({ selectedCell: cell }),
+  setSelectionRange: (startCell, endCell) =>
+    set({
+      selectedCell: startCell,
+      selectionArea: { startCell, endCell },
+      isSelecting: false,
+    }),
   startOrMoveSelection: (rowIndex, colIndex, shiftKeyOrDrag) => {
     const { selectionArea } = get();
     if (shiftKeyOrDrag && selectionArea !== null) {
@@ -103,6 +110,9 @@ export const useClearSelection = () =>
 
 export const useSelectionArea = () =>
   useSelectionStore((state) => state.selectionArea);
+
+export const useSetSelectionRange = () =>
+  useSelectionStore((state) => state.setSelectionRange);
 
 export const selectSelectedCells = (state: SelectionState): CellPosition[] => {
   const { selectionArea } = state;


### PR DESCRIPTION
## Summary
- add `setSelectionRange` to selection store
- allow selecting entire column or row via header click in LiveTable
- test header click selection

## Testing
- `npm test`
- `npm run build` *(fails: Failed to fetch font file)*

------
https://chatgpt.com/codex/tasks/task_e_684383ed679483288111fb8a756ae43a