### PR TITLE
Implement row/column header selection

### DIFF
--- a/frontend/src/__tests__/components/live-table/LiveTableDoc.test.tsx
+++ b/frontend/src/__tests__/components/live-table/LiveTableDoc.test.tsx
@@ -341,4 +341,40 @@ describe("LiveTableDoc - V2 Operations on Clean V2 State", () => {
       expect(rowData?.get(colId1)).toBe(newValue);
     });
   });
+
+  describe("sortRowsByColumn (V2)", () => {
+    it("should sort rows ascending by column", () => {
+      const rowId2 = crypto.randomUUID() as RowId;
+      const r2Map = new Y.Map<CellValue>();
+      r2Map.set(colId1, "b");
+      r2Map.set(colId2, "b2");
+      yDoc.transact(() => {
+        liveTableDoc.yRowData.set(rowId2, r2Map);
+        liveTableDoc.yRowOrder.push([rowId2]);
+      });
+
+      liveTableDoc.sortRowsByColumn("ColA", "asc");
+
+      const firstRowId = liveTableDoc.yRowOrder.get(0);
+      const firstRowData = liveTableDoc.yRowData.get(firstRowId);
+      expect(firstRowData?.get(colId1)).toBe("b");
+    });
+
+    it("should sort rows descending by column", () => {
+      const rowId2 = crypto.randomUUID() as RowId;
+      const r2Map = new Y.Map<CellValue>();
+      r2Map.set(colId1, "a");
+      r2Map.set(colId2, "b2");
+      yDoc.transact(() => {
+        liveTableDoc.yRowData.set(rowId2, r2Map);
+        liveTableDoc.yRowOrder.push([rowId2]);
+      });
+
+      liveTableDoc.sortRowsByColumn("ColA", "desc");
+
+      const firstRowId = liveTableDoc.yRowOrder.get(0);
+      const firstRowData = liveTableDoc.yRowData.get(firstRowId);
+      expect(firstRowData?.get(colId1)).toBe("r1a");
+    });
+  });
 });

--- a/frontend/src/__tests__/components/live-table/LiveTableHeaderClickSelection.test.tsx
+++ b/frontend/src/__tests__/components/live-table/LiveTableHeaderClickSelection.test.tsx
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import LiveTableDisplay from "@/components/live-table/LiveTableDisplay";
+import { useHeaders, useIsTableLoaded, useTableData } from "@/stores/dataStore";
+import { useSetSelectionRange } from "@/stores/selectionStore";
+import { TestDataStoreWrapper } from "./data-store-test-utils";
+
+vi.mock("@/stores/dataStore", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useIsTableLoaded: vi.fn(),
+  useHeaders: vi.fn(),
+  useTableData: vi.fn(),
+}));
+
+vi.mock("@/stores/selectionStore", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useSetSelectionRange: vi.fn(),
+}));
+
+describe("LiveTableDisplay - Header Click Selection", () => {
+  const headers = ["A", "B"];
+  const data = [
+    { A: "1", B: "2" },
+    { A: "3", B: "4" },
+  ];
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(useIsTableLoaded).mockReturnValue(true);
+    vi.mocked(useHeaders).mockReturnValue(headers);
+    vi.mocked(useTableData).mockReturnValue(data);
+  });
+
+  it("selects entire column when header clicked", () => {
+    const mockSetRange = vi.fn();
+    vi.mocked(useSetSelectionRange).mockReturnValue(mockSetRange);
+
+    render(
+      <TestDataStoreWrapper>
+        <LiveTableDisplay />
+      </TestDataStoreWrapper>
+    );
+
+    const headerEl = screen.getByText("A").closest("th") as HTMLElement;
+    fireEvent.click(headerEl);
+
+    expect(mockSetRange).toHaveBeenCalledWith(
+      { rowIndex: 0, colIndex: 0 },
+      { rowIndex: data.length - 1, colIndex: 0 }
+    );
+  });
+
+  it("selects entire row when row header clicked", () => {
+    const mockSetRange = vi.fn();
+    vi.mocked(useSetSelectionRange).mockReturnValue(mockSetRange);
+
+    render(
+      <TestDataStoreWrapper>
+        <LiveTableDisplay />
+      </TestDataStoreWrapper>
+    );
+
+    const rowHeader = screen.getAllByTestId("row-number")[1];
+    fireEvent.click(rowHeader);
+
+    expect(mockSetRange).toHaveBeenCalledWith(
+      { rowIndex: 1, colIndex: 0 },
+      { rowIndex: 1, colIndex: headers.length - 1 }
+    );
+  });
+});

--- a/frontend/src/stores/dataStore.tsx
+++ b/frontend/src/stores/dataStore.tsx
@@ -102,6 +102,7 @@ interface DataActions {
     numColsToAdd: number
   ) => Promise<{ count: number }>;
   reorderColumn: (fromIndex: number, toIndex: number) => void;
+  sortByColumn: (header: string, direction: "asc" | "desc") => void;
   deleteColumns: (colIndices: number[]) => Promise<{ deletedCount: number }>;
   handleColumnResize: (header: string, newWidth: number) => void;
 
@@ -333,6 +334,9 @@ export const DataStoreProvider = ({
       reorderColumn: (fromIndex: number, toIndex: number) => {
         liveTableDoc.reorderColumn(fromIndex, toIndex);
       },
+      sortByColumn: (header: string, direction: "asc" | "desc") => {
+        liveTableDoc.sortRowsByColumn(header, direction);
+      },
       deleteColumns: (colIndices: number[]) =>
         deleteColumns(colIndices, liveTableDoc),
       handleColumnResize: (header: string, newWidth: number) => {
@@ -464,6 +468,8 @@ export const useInsertEmptyColumns = () =>
   useDataStore((state) => state.insertEmptyColumns);
 export const useReorderColumn = () =>
   useDataStore((state) => state.reorderColumn);
+export const useSortByColumn = () =>
+  useDataStore((state) => state.sortByColumn);
 
 // column widths
 export const useColumnWidths = () =>

--- a/frontend/src/stores/selectionStore.ts
+++ b/frontend/src/stores/selectionStore.ts
@@ -18,6 +18,7 @@ export interface SelectionState {
   // true if the user is currently dragging to select cells
   isSelecting: boolean;
   setSelectedCell: (cell: CellPosition | null) => void;
+  setSelectionRange: (start: CellPosition, end: CellPosition) => void;
   startOrMoveSelection: (
     rowIndex: number,
     colIndex: number,
@@ -39,6 +40,12 @@ const initialState: Pick<
 export const selectionStore = createStore<SelectionState>((set, get) => ({
   ...initialState,
   setSelectedCell: (cell) => set({ selectedCell: cell }),
+  setSelectionRange: (startCell, endCell) =>
+    set({
+      selectedCell: startCell,
+      selectionArea: { startCell, endCell },
+      isSelecting: false,
+    }),
   startOrMoveSelection: (rowIndex, colIndex, shiftKeyOrDrag) => {
     const { selectionArea } = get();
     if (shiftKeyOrDrag && selectionArea !== null) {
@@ -103,6 +110,9 @@ export const useClearSelection = () =>
 
 export const useSelectionArea = () =>
   useSelectionStore((state) => state.selectionArea);
+
+export const useSetSelectionRange = () =>
+  useSelectionStore((state) => state.setSelectionRange);
 
 export const selectSelectedCells = (state: SelectionState): CellPosition[] => {
   const { selectionArea } = state;


### PR DESCRIPTION
## Summary
- merge latest `main`
- add column sorting implementation to data store and LiveTableDoc
- allow selecting entire column or row via header click in `LiveTableDisplay`
- expose `setSelectionRange` helper in `selectionStore`
- add tests for sorting and header click selection

## Testing
- `npm test`
- `npm run build` *(fails: Failed to fetch font file)*

------
https://chatgpt.com/codex/tasks/task_e_684383ed679483288111fb8a756ae43a