### PR TITLE
Replace thinking message with pulsing ellipsis

### DIFF
--- a/frontend/src/blocks/chat/chat-detail.tsx
+++ b/frontend/src/blocks/chat/chat-detail.tsx
@@ -16,7 +16,7 @@ import { toast } from "sonner";
 
 import SomethingWentWrong from "@/components/something-went-wrong";
 import { Button } from "@/components/ui/button";
-import { DelayedLoadingSpinner, LoadingSpinner } from "@/components/ui/loading";
+import { DelayedLoadingSpinner, TypingDots } from "@/components/ui/loading";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Textarea } from "@/components/ui/textarea";
 import useIsSSR from "@/hooks/use-is-ssr";
@@ -277,8 +277,7 @@ export default function ChatDetail({ chatId }: ChatDetailProps) {
         <div className="p-4">
           {isThinking && (
             <div className="flex items-center gap-2 text-muted-foreground mb-2">
-              <LoadingSpinner className="w-4 h-4" />
-              <span className="text-sm">Thinking…</span>
+              <TypingDots className="text-sm" />
             </div>
           )}
           <div className="flex gap-2">

--- a/frontend/src/components/ui/loading.tsx
+++ b/frontend/src/components/ui/loading.tsx
@@ -53,3 +53,19 @@ export function DelayedLoadingSpinner({
     />
   );
 }
+
+export function TypingDots({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-0.5",
+        className
+      )}
+      aria-label="typing"
+    >
+      <span className="animate-pulse">.</span>
+      <span className="animate-pulse [animation-delay:150ms]">.</span>
+      <span className="animate-pulse [animation-delay:300ms]">.</span>
+    </span>
+  );
+}


### PR DESCRIPTION
Replace "Thinking..." message with a pulsing ellipsis for a more subtle loading indicator.

---
<a href="https://cursor.com/background-agent?bcId=bc-297c99e5-7e9b-4584-b800-30f5b0f4b585">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-297c99e5-7e9b-4584-b800-30f5b0f4b585">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

