### PR TITLE
Remove Supabase realtime subscription from chat hook

### DIFF
--- a/frontend/docs/chat-realtime.md
+++ b/frontend/docs/chat-realtime.md
@@ -1,0 +1,90 @@
+# Chat Realtime Subscription Notes
+
+The chat experience previously relied on Supabase Realtime to broadcast
+message updates. We temporarily removed the realtime subscription in
+`src/blocks/chat/logic/use-messages.ts` to simplify the client while we
+stabilize the rest of the stack. This document captures what was in place
+and how to restore it if we need realtime updates again.
+
+## When to Re-enable Realtime
+
+Bring this flow back when:
+
+- Multiple users need to view the same chat simultaneously and see live updates.
+- You add features (typing indicators, presence, etc.) that depend on realtime events.
+- Polling or manual refresh introduces unacceptable latency.
+
+## Prerequisites
+
+- A Supabase project with Realtime enabled for the `message` table.
+- Row Level Security (RLS) policies that allow users to subscribe to
+  private channels such as `chat:{chatId}`.
+- The client must have an authenticated session; otherwise the realtime
+  connection will be rejected.
+
+## Implementation Outline
+
+1. **Create the Supabase client**
+   ```ts
+   const supabase = createClient();
+   ```
+
+2. **Get the current session and set the Realtime auth token**
+   ```ts
+   const {
+     data: { session },
+   } = await supabase.auth.getSession();
+   if (!session) return;
+   await supabase.realtime.setAuth(session.access_token);
+   ```
+
+3. **Subscribe to a private channel per chat**
+   ```ts
+   const channel = supabase.channel(`chat:${chatId}`, {
+     config: { private: true },
+   });
+   ```
+
+4. **Listen for broadcast events**
+   ```ts
+   channel.on("broadcast", { event: "UPDATE" }, (eventPayload) => {
+     const newRecord = eventPayload.payload.record;
+     mutate(
+       (current) => (current ? upsertReplace(current, newRecord) : [newRecord]),
+       false
+     );
+   });
+   ```
+
+5. **Subscribe and handle errors**
+   ```ts
+   channel.subscribe((_status, err) => {
+     if (err) {
+       toast.error("Failed to subscribe to chat: " + err.message);
+     }
+   });
+   ```
+
+6. **Cleanup on unmount**
+   ```ts
+   return () => {
+     channel.unsubscribe();
+   };
+   ```
+
+7. **Update React hooks**
+   - Re-introduce `useAsyncEffect` (or `useEffect`) to manage the
+     subscription lifecycle.
+   - Re-add local state to store the channel instance if you need to
+     reference it during cleanup.
+
+## Testing Checklist
+
+- Open two browser sessions with different users; confirm that a message
+  sent in one appears in the other without a refresh.
+- Verify that the toast notifications surface subscription errors.
+- Confirm that unsubscribing happens on component unmount to avoid
+  duplicate events.
+
+Keeping these notes around should make it straightforward to restore the
+feature once we are ready for realtime again.

--- a/frontend/src/blocks/chat/logic/use-messages.ts
+++ b/frontend/src/blocks/chat/logic/use-messages.ts
@@ -1,12 +1,4 @@
-import { useState } from "react";
-
-import { toast } from "sonner";
 import useSWR from "swr";
-
-import { RealtimeChannel } from "@supabase/supabase-js";
-
-import { useAsyncEffect } from "@/hooks/use-async-effect";
-import { upsertReplace } from "@/utils/data";
 import { createClient } from "@/utils/supabase/client";
 
 /**
@@ -18,10 +10,13 @@ import { createClient } from "@/utils/supabase/client";
  * if (isLoading) return <DelayedLoadingSpinner />;
  * if (error || !data) return <SomethingWentWrong />;
  * return ...
+ *
+ * Realtime updates were previously handled via Supabase's realtime channels.
+ * If you need to re-enable that behavior, see
+ * `/frontend/docs/chat-realtime.md` for implementation notes.
  */
 export default function useMessages(chatId: string) {
   const supabase = createClient();
-  const [myChannel, setMyChannel] = useState<RealtimeChannel | null>(null);
 
   const { data, error, isLoading, mutate } = useSWR(
     chatId ? `/chat/${chatId}/messages` : null,
@@ -48,41 +43,6 @@ export default function useMessages(chatId: string) {
       // use if data changes consistently & not using realtime
       refreshInterval: 0,
     }
-  );
-
-  useAsyncEffect(
-    async () => {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-      if (!session) return;
-      await supabase.realtime.setAuth(session.access_token);
-      const myChannel = supabase.channel(`chat:${chatId}`, {
-        config: { private: true },
-      });
-      myChannel
-        .on("broadcast", { event: "UPDATE" }, (eventPayload) => {
-          const newRecord = eventPayload.payload.record;
-          mutate(
-            (data) => (data ? upsertReplace(data, newRecord) : [newRecord]),
-            false
-          );
-        })
-        .subscribe((_status, err) => {
-          if (err) {
-            console.error(err);
-            toast.error("Failed to subscribe to chat: " + err.message);
-          } else {
-            toast.success("Subscribed to chat");
-          }
-        });
-      setMyChannel(myChannel);
-    },
-    async () => {
-      myChannel?.unsubscribe();
-      setMyChannel(null);
-    },
-    [supabase]
   );
 
   return { data, error, isLoading, mutate };


### PR DESCRIPTION
## Summary
- remove the Supabase realtime channel wiring from the chat messages hook
- document how to reintroduce the realtime subscription in the future

## Testing
- npm test
- npm run build *(fails: Module not found: Can't resolve 'ai/react')*

------
https://chatgpt.com/codex/tasks/task_e_68dcae6ca6508328a3631d27963db75b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes Supabase Realtime logic from `useMessages` and adds documentation on how to re-enable realtime updates.
> 
> - **Chat Hook (`frontend/src/blocks/chat/logic/use-messages.ts`)**:
>   - Remove Supabase Realtime channel setup, auth, event handling, toasts, and cleanup (`useState`, `useAsyncEffect`, `RealtimeChannel`, `upsertReplace`).
>   - Retain SWR-based fetch for messages; add comment pointing to docs for re-enabling realtime.
> - **Docs**:
>   - Add `frontend/docs/chat-realtime.md` with prerequisites, implementation outline, cleanup, and testing checklist to restore realtime subscriptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 856b865c3140b98c40067f77ce4c2a8dc1261096. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->