### PR TITLE
Remove supabase chat subscription and document

### DIFF
--- a/frontend/src/blocks/chat/README-realtime.md
+++ b/frontend/src/blocks/chat/README-realtime.md
@@ -1,0 +1,46 @@
+### Supabase Realtime for Chat (disabled)
+
+The chat feature currently uses SWR fetching without realtime. To re-enable Supabase Realtime broadcast updates for messages:
+
+1. Ensure DB trigger and policy exist
+   - Confirm the migration that defines `public.broadcast_chat_changes()` and the select policy on `realtime.messages` is applied.
+   - The broadcast topic format used is `chat:{chat_id}`.
+
+2. Client auth for realtime
+   - Obtain a session and set the realtime token: `await supabase.realtime.setAuth(session.access_token)`.
+
+3. Subscribe to the private broadcast channel
+   - Create a channel with `supabase.channel(`chat:${chatId}`, { config: { private: true } })`.
+   - Listen for `broadcast` events with `{ event: "UPDATE" }` and upsert the received record into the local messages state.
+
+4. Unsubscribe on cleanup
+   - Call `channel.unsubscribe()` when the component unmounts or `chatId` changes.
+
+5. SWR settings
+   - Keep `revalidateOnFocus` enabled if you want refresh on tab focus.
+   - `refreshInterval` should remain `0` when using realtime to avoid unnecessary polling.
+
+Example hook outline (for reference only):
+
+```ts
+const supabase = createClient();
+const { data, mutate } = useSWR(`/chat/${chatId}/messages`, fetcher, { refreshInterval: 0 });
+
+useEffect(() => {
+  let channel: RealtimeChannel | null = null;
+  (async () => {
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session) return;
+    await supabase.realtime.setAuth(session.access_token);
+    channel = supabase.channel(`chat:${chatId}`, { config: { private: true } });
+    channel.on('broadcast', { event: 'UPDATE' }, (payload) => {
+      const newRecord = payload.payload.record;
+      mutate((prev) => prev ? upsertReplace(prev, newRecord) : [newRecord], false);
+    }).subscribe();
+  })();
+  return () => { channel?.unsubscribe(); };
+}, [chatId]);
+```
+
+If you use this again, remember to avoid user-facing error details; log errors to the console and show generic toasts.
+


### PR DESCRIPTION
Remove Supabase realtime subscription from the chat component and add documentation for future re-enablement.

---
<a href="https://cursor.com/background-agent?bcId=bc-d43c1476-14e4-4725-bbc1-71cfd7df93ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d43c1476-14e4-4725-bbc1-71cfd7df93ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables Supabase Realtime in chat by removing subscription code from `use-messages` and adds a README with steps to re-enable it.
> 
> - **Chat**:
>   - **Logic (`frontend/src/blocks/chat/logic/use-messages.ts`)**: Remove Supabase Realtime channel subscription/auth, related state/effects, and toasts; rely solely on SWR fetching for messages.
>   - **Docs (`frontend/src/blocks/chat/README-realtime.md`)**: Add concise guide to re-enable Supabase Realtime (DB trigger/policy, client auth, private channel subscription, cleanup, SWR settings, example outline).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62c857d7d1f7a2fd6751223f80de37be0ffcf195. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->