### PR TITLE
Manage chat interface state and history

### DIFF
--- a/frontend/src/__tests__/app/(main)/chat/page.test.tsx
+++ b/frontend/src/__tests__/app/(main)/chat/page.test.tsx
@@ -54,7 +54,7 @@ describe("ChatPage", () => {
     expect(screen.getByText("Log In")).toBeInTheDocument();
   });
 
-  it("should render chat components when user is logged in", async () => {
+  it("should render container when user is logged in", async () => {
     const mockUser: User = {
       id: "user-123",
       email: "test@example.com",
@@ -82,7 +82,6 @@ describe("ChatPage", () => {
     render(page);
 
     expect(screen.getByTestId("container")).toBeInTheDocument();
-    expect(screen.getByTestId("chat-list-component")).toBeInTheDocument();
     expect(screen.queryByText("You need to log in")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(main)/chat/history/page.tsx
+++ b/frontend/src/app/(main)/chat/history/page.tsx
@@ -1,9 +1,9 @@
-import ChatRedirect from "@/blocks/chat/chat-redirect";
+import ChatList from "@/blocks/chat/chat-list";
 import ShouldLogIn from "@/components/should-log-in";
 import Container from "@/components/ui/container";
 import { getUser } from "@/utils/supabase/server";
 
-export default async function ChatPage() {
+export default async function ChatHistoryPage() {
   const { user } = await getUser();
 
   if (!user) {
@@ -12,14 +12,15 @@ export default async function ChatPage() {
         icon="files"
         message="You need to log in to view and manage chats. Sign in to get started."
         title="Chat"
-        redirect="/chat"
+        redirect="/chat/history"
       />
     );
   }
 
   return (
     <Container>
-      <ChatRedirect />
+      <ChatList />
     </Container>
   );
 }
+

--- a/frontend/src/blocks/chat/chat-detail.tsx
+++ b/frontend/src/blocks/chat/chat-detail.tsx
@@ -132,6 +132,13 @@ export default function ChatDetail({ chatId }: ChatDetailProps) {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, streamingMessages, forceThinking]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem("lastChatId", chatId);
+    } catch {}
+  }, [chatId]);
+
   const serverStreaming = hasAssistantStreaming(messages);
   const isThinking = forceThinking || serverStreaming;
 
@@ -211,7 +218,7 @@ export default function ChatDetail({ chatId }: ChatDetailProps) {
             </p>
           </div>
           <Button variant="outline" size="sm" asChild>
-            <Link href="/chat">Chat History</Link>
+            <Link href="/chat/history">Chat History</Link>
           </Button>
         </div>
       </div>

--- a/frontend/src/blocks/chat/chat-redirect.tsx
+++ b/frontend/src/blocks/chat/chat-redirect.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { toast } from "sonner";
+
+import createChat from "@/blocks/chat/logic/create-chat";
+import useChats from "@/blocks/chat/logic/use-chats";
+import { DelayedLoadingSpinner } from "@/components/ui/loading";
+import useIsSSR from "@/hooks/use-is-ssr";
+import { useUser } from "@/utils/supabase/client";
+
+export default function ChatRedirect() {
+  const isSSR = useIsSSR();
+  const user = useUser();
+  const { data, isLoading } = useChats();
+  const navigatedRef = useRef(false);
+
+  useEffect(() => {
+    if (isSSR) return;
+    if (!user) return;
+    if (isLoading) return;
+    if (navigatedRef.current) return;
+
+    navigatedRef.current = true;
+
+    const stored = typeof window !== "undefined" ? window.localStorage.getItem("lastChatId") : null;
+    const chats = data || [];
+    const hasStored = stored && chats.some((c) => c.id === stored);
+
+    if (hasStored && stored) {
+      window.location.replace(`/chat/${stored}`);
+      return;
+    }
+
+    (async () => {
+      try {
+        const newChat = await createChat("New Chat", user.id);
+        window.location.replace(`/chat/${newChat.id}`);
+      } catch {
+        toast.error("Failed to start a new chat");
+        window.location.replace("/chat/history");
+      }
+    })();
+  }, [isSSR, user, isLoading, data]);
+
+  if (isSSR) return <></>;
+  return <DelayedLoadingSpinner />;
+}
+


### PR DESCRIPTION
Default the `/chat` route to open the last viewed chat or a new one, and create a dedicated `/chat/history` page for chat list access.

---
<a href="https://cursor.com/background-agent?bcId=bc-19cd43d2-5028-4252-9c4a-5e25173d6efd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-19cd43d2-5028-4252-9c4a-5e25173d6efd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

